### PR TITLE
Drops deprecated ya.mgr_emit in favor of ya.emit

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -117,6 +117,6 @@ return {
 		table.insert(flags, tostring(secondary_command))
 
 		-- Execute the main command with the parsed parameters
-		ya.mgr_emit(tostring(main_command), flags)
+		ya.emit(string.format("mgr:%s", main_command), flags)
 	end,
 }


### PR DESCRIPTION
While `ya.mgr_emit` is still available, eventually it will be removed. Now, the real reason for this PR, is to avoid the deprecated warning.